### PR TITLE
fix(*): allow _ in right name

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -78,5 +78,15 @@ describe('access.js', function() {
 
       expect(result).toBe(true);
     });
+
+    it('test #2: is Allowed should return true', () => {
+      const has = ['filebrowser.local.read'];
+
+      const needs = 'filebrowser.local.read.jetflash_transcend_8gb_1';
+
+      const result = uut.isAllowed(has, needs);
+
+      expect(result).toBe(true);
+    });
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ function checkOr(has, requires) {
   has.forEach(function(right) {
     requires.forEach(function(required) {
       right = escapeRegExp(right);
-      var regExp = new RegExp('^' + right + '(\\.[a-zA-Z0-9\\.]*)*$');
+      var regExp = new RegExp('^' + right + '(\\.[a-zA-Z0-9_\\.]*)*$');
       found = found || regExp.test(required);
     });
   });


### PR DESCRIPTION
USB stick has `_` in name which is used as folder name to select between possible multiple usb devices.